### PR TITLE
korjaukset projektirepoon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Jotta voit osallistua mukaan projektiin, niin tarvitset siihen seuraavat asiat:
  - GitHub-palvelun käyttäjätunnus
  - neutroni-palvelimelle on määritelty SSH-avaimet GitHub-palveluun
 
+Jos sinulla ei ole määritelty SSH-avaimia GitHub-palveluun, niin ohjeet avaimen määrittelyyn löydät [tältä ohjesivulta](https://neutroni.hayo.fi/~pta/book/sovelluksen-julkaisu/valmistelut/ssh-avaimet.html).
+
 ## Projektin kopiointi omalle tunnukselle
 
 Saat projektin toimimaan neutroni-palvelimella omalla tunnuksellasi seuraavilla vaiheilla:

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,5 @@
 <?php
 
-
-
 // Suoritetaan projektin alustusskripti.
 require_once '../src/init.php';
 
@@ -22,7 +20,6 @@ switch ($request) {
       $formdata = cleanArrayData($_POST);
       require_once CONTROLLER_DIR . 'uusihaku.php';
       $tulos = lisaaHakusana($formdata);
-      print_r($tulos);
       echo "Haku lisätty";
       break;
     } else {
@@ -31,6 +28,6 @@ switch ($request) {
     }
   default:
     echo $templates->render('notfound');
-}    
+}
 
-?> 
+?>


### PR DESCRIPTION
Tämä päivitys korjaa projektireposta seuraavat asiat:
 - lisää linkin ohjesivulle, jossa neuvotaan SSH-avainten luominen
 - poistaa uuden hakusanan lisäksen yhteydessä paluumuuttujan arvon tulostuksen